### PR TITLE
Modify: reset.css에서 padding, margin 삭제

### DIFF
--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -79,8 +79,6 @@ time,
 mark,
 audio,
 video {
-  margin: 0;
-  padding: 0;
   border: 0;
   vertical-align: baseline;
 }


### PR DESCRIPTION
## PR 요약

reset.css에서 padding, margin 삭제

## 변경 내용
reset.css에서 
- padding: 0
- margin: 0
삭제
### **기능 추가:**



### **버그 수정:**



### **성능 개선:**



### **기타:**



## 마주했던 문제 상황



## 질문사항



## 관련 이슈

### 메인 이슈

#31 

### 참고 이슈


