### PR TITLE
Feat: 상세 페이지 좋아요 추가 및 취소 기능 구현

### DIFF
--- a/src/pages/details/DetailsPage.ts
+++ b/src/pages/details/DetailsPage.ts
@@ -1,5 +1,5 @@
 import { getAxios } from '../../utils/axios';
-import type { BookmarkCreateRes, BookmarkDeleteRes, BookmarkLikeReq, BookmarkType, PostItem, PostResponse, RecentPost, UserBookmarkListRes, UserResponse } from '../../utils/types';
+import type { BookmarkCreateRes, BookmarkDeleteRes, BookmarkLikeReq, BookmarkType, PostItem, PostLikeListRes, PostResponse, RecentPost, UserBookmarkListRes, UserResponse } from '../../utils/types';
 
 const mainContents = document.querySelector('.details-maincontents') as HTMLElement;
 const titleContents = document.querySelector('.details-title') as HTMLParagraphElement;
@@ -24,6 +24,10 @@ const subscribeButtonEl = document.querySelector('.subscribe-button') as HTMLBut
 let subscribed = false;
 
 let currentBookmarkId: number | null = null;
+
+// -------------------- 좋아요 상태 --------------------
+let liked = false; // 이 게시글을 내가 좋아요 했는지
+let currentLikeId: number | null = null; // 좋아요 row id (취소할 때 사용)
 
 // 1. 로그인 여부 확인 함수 (세션 스토리지에 accessToken 기준)
 function isLoggedIn() {
@@ -64,25 +68,29 @@ updateSubscribeButtonUI();
 // 좋아요 버튼
 
 // 초기 좋아요 개수 (DOM에 적힌 숫자 기준)
-let likeCount = Number(likeCountEl.textContent) || 0;
 
-// 현재 이 사용자가 좋아요를 누른 상태인지 여부
-let liked = false;
-
-likeButton.addEventListener('click', () => {
-  liked = !liked;
+function updateLikeButtonUI() {
+  if (!likeButton) return;
 
   likeButton.setAttribute('aria-pressed', String(liked));
+}
 
-  if (liked) {
-    likeCount += 1; // 좋아요 누름
-  } else {
-    likeCount -= 1; // 좋아요 취소
-  }
+let likeCount = Number(likeCountEl.textContent) || 0;
 
-  // 화면에 숫자 반영
-  likeCountEl.textContent = String(likeCount);
-});
+// likeButton.addEventListener('click', () => {
+//   liked = !liked;
+
+//   likeButton.setAttribute('aria-pressed', String(liked));
+
+//   if (liked) {
+//     likeCount += 1; // 좋아요 누름
+//   } else {
+//     likeCount -= 1; // 좋아요 취소
+//   }
+
+//   // 화면에 숫자 반영
+//   likeCountEl.textContent = String(likeCount);
+// });
 
 // url에서 id 값 꺼내기
 const params = new URLSearchParams(location.search);
@@ -108,6 +116,7 @@ async function loadPost(id: string) {
 
     if (data.ok === 1) {
       const post = data.item;
+
       console.log('post.user 실제 값:', post.user);
       console.log('posts 응답 전체:', post);
       console.log(data.item);
@@ -164,10 +173,18 @@ async function loadPost(id: string) {
       }
       currentAuthorId = post.user._id;
       lookUpAuthor(currentAuthorId); // 게시글 작성자의 id
+
+      // 게시글 좋아요 개수
+      likeCount = post.likes ?? 0;
+      likeCountEl.textContent = String(likeCount);
+
       // 로그인 되어 있을 때만 구독 상태 조회
+
       if (isLoggedIn()) {
         checkSubscribe(currentAuthorId);
+        checkLike(post._id);
       }
+
       // 최근 본 글로 저장
       saveRecentPost(post);
     }
@@ -216,11 +233,6 @@ async function lookUpAuthor(authorId: number) {
           writerExplain.textContent = biography;
         }
       }
-
-      // 좋아요 수
-      const authorLikes = author.likedBy.users;
-      likeCount = authorLikes;
-      likeCountEl.textContent = String(authorLikes);
 
       // 구독자 수
       const authorBookmarked = author.bookmarkedBy.users;
@@ -276,6 +288,8 @@ function saveRecentPost(post: PostItem) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
 }
 
+// ----------------- 구독 기능 구현 ---------------------
+
 // 구독 상태 조회
 async function checkSubscribe(authorId: number) {
   const axios = getAxios();
@@ -309,6 +323,7 @@ subscribeButtonEl.addEventListener('click', () => {
 
   if (!isLoggedIn()) {
     alert('로그인이 필요한 서비스입니다.');
+    location.href = '/src/pages/login/SignIn.html';
     return;
   }
 
@@ -375,5 +390,111 @@ async function cancelSubscribe(bookmarkId: number) {
     }
   } catch (err) {
     console.error('구독 취소 에러:', err);
+  }
+}
+
+// -------------------- 좋아요 기능구현 ---------------------------
+
+// 좋아요 목록 조회
+
+async function checkLike(postId: number) {
+  const axios = getAxios();
+  const type: BookmarkType = 'post';
+
+  try {
+    const { data } = await axios.get<PostLikeListRes>(`bookmarks/${type}`, {
+      params: {
+        is_like: true, // 좋아요만 조회
+      },
+    });
+    console.log('내가 좋아요한 게시글 목록:', data.item);
+
+    if (data.ok === 1) {
+      const likeList = data.item;
+
+      // 이 게시글을 좋아요한 row id 찾기!
+      const find = likeList.find((item) => item.post._id === postId);
+
+      if (find) {
+        liked = true;
+        currentLikeId = find._id;
+      }
+      updateLikeButtonUI();
+    }
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+// -------------------- 좋아요 버튼 토글 --------------------
+likeButton.addEventListener('click', () => {
+  console.log('좋아요 버튼 클릭됨!');
+
+  if (!isLoggedIn()) {
+    alert('로그인이 필요한 서비스입니다.');
+    location.href = '/src/pages/login/SignIn.html';
+    return;
+  }
+
+  // 이미 좋아요 상태라면 → 취소
+  if (liked) {
+    if (currentLikeId != null) {
+      cancelLike(currentLikeId);
+    }
+  } else {
+    addLike(Number(postId));
+  }
+});
+
+// -------------------- 좋아요 추가 --------------------
+async function addLike(postId: number) {
+  const axios = getAxios();
+  const type: BookmarkType = 'post';
+
+  const body: BookmarkLikeReq = {
+    target_id: postId,
+    is_like: true,
+  };
+
+  try {
+    console.log('좋아요 추가 보냄:', postId);
+    const { data } = await axios.post<BookmarkCreateRes>(`/bookmarks/${type}`, body);
+    console.log('좋아요 추가 응답:', data);
+
+    if (data.ok === 1) {
+      liked = true;
+      updateLikeButtonUI();
+
+      // 화면 좋아요 수 +1
+      likeCount += 1;
+      likeCountEl.textContent = String(likeCount);
+    } else {
+      console.error('좋아요 실패 응답ㅜ', data);
+    }
+  } catch (err) {
+    console.error('좋아요 추가 에러:', err);
+  }
+}
+
+// -------------------- 좋아요 취소 --------------------
+async function cancelLike(likeId: number) {
+  const axios = getAxios();
+
+  try {
+    const { data } = await axios.delete<BookmarkDeleteRes>(`/bookmarks/${likeId}`);
+    console.log('좋아요 취소 응답:', data);
+
+    if (data.ok === 1) {
+      liked = false;
+      updateLikeButtonUI();
+
+      // 화면 좋아요 수 -1 (최소 0 보장)
+      likeCount = Math.max(0, likeCount - 1);
+      likeCountEl.textContent = String(likeCount);
+    } else {
+      console.error('좋아요 취소 실패 응답ㅜ', data);
+    }
+  } catch (err) {
+    console.error('좋아요 취소 에러:', err);
   }
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -95,6 +95,7 @@ export interface PostItem {
   updatedAt: string;
   bookmarks: number;
   myBookmarkId: number;
+  likes: number;
 }
 
 export interface Pagination {
@@ -168,6 +169,12 @@ export interface PostTargetBookmark extends BaseBookmarkItem {
 export type UserBookmarkListRes = {
   ok: 1;
   item: UserBookmarkItem[];
+};
+
+// 사용자가 좋아요한 게시글 리스트
+export type PostLikeListRes = {
+  ok: 1;
+  item: PostTargetBookmark[];
 };
 
 // 북마크, 좋아요 추가 응답


### PR DESCRIPTION
## PR 요약

- DetailsPage.ts에 좋아요 추가 및 취소 기능 구현

## 변경 내용
- types.ts에 PostItem 타입에 likes 프로퍼티 추가

### **기능 추가:**
- 로그인 하지 않았을 시 좋아요 버튼 및 구독 버튼 클릭 시 '로그인이 필요합니다.' 알림창 뜨고 로그인 페이지로 이동
- 좋아요 추가 시 게시글 좋아요 수 1 증가 (좋아요 한 페이지 들어가면 좋아요 수가 기록되어 있음)
- 좋아요 취소 시 좋아요 수 1 감소


## 마주했던 문제 상황

- 문제: 좋아요 목록 조회 시 좋아요 목록이 뜨지 않아 Api 명세서를 보니 파라미터로 is_like를 넘겨줘야됨.
   - 해결 방안: get 메서드에 두 번째 인수 값으로 아래 코드 추가
  ```tsx
  {
     params: {
        is_like: true, // 좋아요만 조회
      },
    }
```


### 메인 이슈

- #86 

